### PR TITLE
Reserve C-u hotkey

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -52,6 +52,21 @@ export default class EmacsBindingsPlugin extends Plugin {
       },
     })
 
+    this.addCommand({
+      id: 'emacs-reserve3',
+      name: 'Reserve hotkey for emacs3',
+      hotkeys: [{ modifiers: ['Ctrl'], key: 'u' }],
+      editorCallback: (editor: Editor, view: MarkdownView) => {
+        const handler = EmacsBindingsPlugin.handlerMap.get(
+          // @ts-expect-error TS2339: Property 'cm' does not exist on type 'Editor'
+          view.editor.cm as EditorView
+        )
+        if (handler !== undefined) handler.handleKeyData(
+          ['u', 'C-', 'u']
+        )
+      },
+    })
+
     // TODO: how to deal with macos keyes.... hmm
     // Prec.highest(
     //   keymap.of([

--- a/src/main.ts
+++ b/src/main.ts
@@ -215,6 +215,10 @@ export class EmacsHandler {
   handleKeyboard(e: KeyboardEvent) {
     // console.log('handleKeyboard', e);
     const keyData = EmacsHandler.getKey(e)
+    return this.handleKeyData(keyData)
+  }
+
+  handleKeyData(keyData: string[]) {
     const result = this.findCommand(keyData)
 
     // console.log('  keyData=', keyData, ' result=', result);


### PR DESCRIPTION
On my NixOS system, Obsidian handles C-u as Undo without ever calling the keyboard handler. This addition claims the key for the Emacs keybindings.